### PR TITLE
Update hash add/get/list/delete methods + Other minor fixes

### DIFF
--- a/hashlookup/hashlookup.go
+++ b/hashlookup/hashlookup.go
@@ -20,20 +20,25 @@ import (
     "errors"
 
     "github.com/libp2p/go-libp2p-core/host"
+    "github.com/libp2p/go-libp2p-core/pnet"
     "github.com/libp2p/go-libp2p-discovery"
+
+    "github.com/multiformats/go-multiaddr"
 
     "github.com/Multi-Tier-Cloud/hash-lookup/hl-common"
 )
 
-func AddHash(serviceName, hash, dockerId string) (
-    addResponse string, err error) {
+func AddHash(bootstraps []multiaddr.Multiaddr, psk pnet.PSK,
+        serviceName, hash, dockerId string) (
+        addResponse string, err error) {
 
     reqBytes, err := marshalAddRequest(serviceName, hash, dockerId)
     if err != nil {
         return "", err
     }
 
-    response, err := common.SendRequest(common.AddProtocolID, reqBytes)
+    response, err := common.SendRequest(bootstraps, psk,
+        common.AddProtocolID, reqBytes)
     if err != nil {
         return "", err
     }
@@ -68,8 +73,11 @@ func marshalAddRequest(serviceName, hash, dockerId string) (
     return json.Marshal(reqInfo)
 }
 
-func GetHash(query string) (contentHash, dockerHash string, err error) {
-    response, err := common.SendRequest(common.GetProtocolID, []byte(query))
+func GetHash(bootstraps []multiaddr.Multiaddr, psk pnet.PSK, query string) (
+        contentHash, dockerHash string, err error) {
+
+    response, err := common.SendRequest(bootstraps, psk,
+        common.GetProtocolID, []byte(query))
     if err != nil {
         return "", "", err
     }
@@ -107,10 +115,11 @@ func unmarshalGetResponse(getResponse []byte) (
     return respInfo.ContentHash, respInfo.DockerHash, nil
 }
 
-func ListHashes() (
+func ListHashes(bootstraps []multiaddr.Multiaddr, psk pnet.PSK) (
     serviceNames, contentHashes, dockerHashes []string, err error) {
 
-    response, err := common.SendRequest(common.ListProtocolID, []byte{})
+    response, err := common.SendRequest(bootstraps, psk,
+        common.ListProtocolID, []byte{})
     if err != nil {
         return nil, nil, nil, err
     }
@@ -149,8 +158,10 @@ func unmarshalListResponse(listResponse []byte) (
         respInfo.DockerHashes, nil
 }
 
-func DeleteHash(serviceName string) (deleteResponse string, err error) {
-    response, err := common.SendRequest(
+func DeleteHash(bootstraps []multiaddr.Multiaddr, psk pnet.PSK,
+        serviceName string) (deleteResponse string, err error) {
+
+    response, err := common.SendRequest(bootstraps, psk,
         common.DeleteProtocolID, []byte(serviceName))
     if err != nil {
         return "", err

--- a/hl-cli/hl-cli.go
+++ b/hl-cli/hl-cli.go
@@ -285,6 +285,7 @@ func getHash(fileNode files.Node) (hash string, err error) {
     if err != nil {
         return "", err
     }
+    defer nilIpfsNode.Close()
 
     bserv := blockservice.New(nilIpfsNode.Blockstore, nilIpfsNode.Exchange)
     dserv := dag.NewDAGService(bserv)

--- a/hl-common/hl-common.go
+++ b/hl-common/hl-common.go
@@ -23,8 +23,11 @@ import (
     "time"
 
     "github.com/libp2p/go-libp2p-core/host"
+    "github.com/libp2p/go-libp2p-core/pnet"
     "github.com/libp2p/go-libp2p-core/protocol"
     "github.com/libp2p/go-libp2p-discovery"
+
+    "github.com/multiformats/go-multiaddr"
 
     "github.com/Multi-Tier-Cloud/common/p2pnode"
     "github.com/Multi-Tier-Cloud/common/p2putil"
@@ -63,17 +66,19 @@ func init() {
     log.SetFlags(log.Ldate | log.Lmicroseconds | log.Lshortfile)
 }
 
-func SendRequest(protocolID protocol.ID, request []byte) (
+func SendRequest(bootstraps []multiaddr.Multiaddr, psk pnet.PSK,
+    protocolID protocol.ID, request []byte) (
     response []byte, err error) {
 
     ctx := context.Background()
     nodeConfig := p2pnode.NewConfig()
+    nodeConfig.BootstrapPeers = bootstraps
+    nodeConfig.PSK = psk
     node, err := p2pnode.NewNode(ctx, nodeConfig)
     if err != nil {
         return nil, err
     }
-    defer node.Host.Close()
-    defer node.DHT.Close()
+    defer node.Close()
 
     return SendRequestWithHostRouting(
         ctx, node.Host, node.RoutingDiscovery, protocolID, request)

--- a/hl-service/hl-service.go
+++ b/hl-service/hl-service.go
@@ -132,7 +132,7 @@ func main() {
 
     if !(*newEtcdClusterFlag) {
         initialCluster, err = sendMemberAddRequest(
-            etcdName, etcdPeerUrl, *localFlag, *bootstraps)
+            etcdName, etcdPeerUrl, *localFlag, *bootstraps, *psk)
         if err != nil {
             panic(err)
         }
@@ -209,8 +209,7 @@ func main() {
             panic(err)
         }
     }
-    defer node.Host.Close()
-    defer node.DHT.Close()
+    defer node.Close()
 
     // log.Println("Host ID:", node.Host.ID())
     // log.Println("Listening on:", node.Host.Addrs())

--- a/hl-service/member-add.go
+++ b/hl-service/member-add.go
@@ -22,6 +22,7 @@ import (
     "strings"
 
 	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/pnet"
 	"github.com/libp2p/go-libp2p-core/protocol"
 
     "go.etcd.io/etcd/clientv3"
@@ -42,10 +43,12 @@ type memberAddRequest struct {
 
 func sendMemberAddRequest(
     newMemName, newMemPeerUrl string, local bool,
-    bootstraps []multiaddr.Multiaddr) (initialCluster string, err error) {
+    bootstraps []multiaddr.Multiaddr,
+    psk pnet.PSK) (initialCluster string, err error) {
 
     ctx := context.Background()
     nodeConfig := p2pnode.NewConfig()
+    nodeConfig.PSK = psk
     if local {
         nodeConfig.BootstrapPeers = []multiaddr.Multiaddr{}
     } else if len(bootstraps) > 0 {
@@ -55,8 +58,7 @@ func sendMemberAddRequest(
     if err != nil {
         return "", err
     }
-    defer node.Host.Close()
-    defer node.DHT.Close()
+    defer node.Close()
 
     reqInfo := memberAddRequest{newMemName, newMemPeerUrl}
     reqBytes, err := json.Marshal(reqInfo)


### PR DESCRIPTION
1) Pass bootstraps and PSK to Add/Get/List/Delete Hash functions
  - To be used in the SendRequest() function, which has also been
    modified to make use of these new params in creating its Node
  - Fixes regression caused by recent changes that removed hard-coded
    bootstrap addresses from common/p2pnode
  - This is a pre-req for fixing Multi-Tier-Cloud/service-manager#39
2) Call Close() on nodes created by NewNode() when finished with them
  - Newly introduced method/member introduced in v0.8.1 of common repo
  - This will also cancel the contexts used in node.Host and node.DHT,
    so they shouldn't need to be explicitly closed
3) Pass PSK to sendMemberAddRequest() to use when it creates a new Node